### PR TITLE
Use libc++ on mac.

### DIFF
--- a/brightray.gypi
+++ b/brightray.gypi
@@ -35,8 +35,8 @@
     'xcode_settings': {
       'ALWAYS_SEARCH_USER_PATHS': 'NO',
       'ARCHS': ['x86_64'],
-      'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++11',
-      'CLANG_CXX_LIBRARY': 'libstdc++',
+      'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
+      'CLANG_CXX_LIBRARY': 'libc++',
       'COMBINE_HIDPI_IMAGES': 'YES',
       'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',
       'GCC_ENABLE_CPP_RTTI': 'NO',


### PR DESCRIPTION
libchromiumcontent uses [`libc++` library](https://github.com/brightray/libchromiumcontent/commit/7df5689ae2adf86bd3d75667cc85012e73938c88) since chrom39 on mac. We should also use the same library while building brightray, otherwise link error(undefined symbol) will occur.