### PR TITLE
implement AllowCeritifcateError to allow requests with ignoreCertificate...

### DIFF
--- a/browser/browser_client.cc
+++ b/browser/browser_client.cc
@@ -12,7 +12,9 @@
 
 #include "base/base_paths.h"
 #include "base/path_service.h"
+#include "base/command_line.h"
 #include "content/public/common/url_constants.h"
+#include "content/public/common/content_switches.h"
 
 namespace brightray {
 
@@ -95,6 +97,27 @@ base::FilePath BrowserClient::GetDefaultDownloadDirectory() {
     path = path.Append(FILE_PATH_LITERAL("Downloads"));
 
   return path;
+}
+
+void BrowserClient::AllowCertificateError(int render_process_id,
+                                          int render_frame_id,
+                                          int cert_error,
+                                          const net::SSLInfo& ssl_info,
+                                          const GURL& request_url,
+                                          content::ResourceType resource_type,
+                                          bool overridable,
+                                          bool strict_enforcement,
+                                          bool expired_previous_decision,
+                                          const base::Callback<void(bool)>& callback,
+                                          content::CertificateRequestResultType* result) {
+  LOG(WARNING) << "AllowCertificateError : " << request_url;
+  base::CommandLine* cmd_line = base::CommandLine::ForCurrentProcess();
+  if (cmd_line->HasSwitch(switches::kIgnoreCertificateErrors)) {
+    *result = content::CERTIFICATE_REQUEST_RESULT_TYPE_CONTINUE;
+  } else {
+    *result = content::CERTIFICATE_REQUEST_RESULT_TYPE_DENY;
+  }
+  return;
 }
 
 content::DevToolsManagerDelegate* BrowserClient::GetDevToolsManagerDelegate() {

--- a/browser/browser_client.h
+++ b/browser/browser_client.h
@@ -6,6 +6,7 @@
 #define BRIGHTRAY_BROWSER_BROWSER_CLIENT_H_
 
 #include "content/public/browser/content_browser_client.h"
+#include "content/public/common/resource_type.h"
 
 namespace brightray {
 
@@ -52,6 +53,17 @@ class BrowserClient : public content::ContentBrowserClient {
       std::vector<std::string>* additional_schemes) override;
   base::FilePath GetDefaultDownloadDirectory() override;
   content::DevToolsManagerDelegate* GetDevToolsManagerDelegate() override;
+  void AllowCertificateError(int render_process_id,
+                             int render_frame_id,
+                             int cert_error,
+                             const net::SSLInfo& ssl_info,
+                             const GURL& request_url,
+                             content::ResourceType resource_type,
+                             bool override,
+                             bool strict_enforcement,
+                             bool expired_previous_decision,
+                             const base::Callback<void(bool)>& callback,
+                             content::CertificateRequestResultType* result) override;
 
   BrowserMainParts* browser_main_parts_;
   scoped_ptr<NotificationPresenter> notification_presenter_;


### PR DESCRIPTION
...Errors flag

Fixes https://github.com/atom/atom-shell/issues/1221 . Added corresponding test case here https://github.com/atom/atom-shell/pull/1224